### PR TITLE
Move TTY detection to dbus-d0-smartmeter.py remove it from service/run - FIX startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ You have to edit `config.ini`. Please note the comments there as explanation!
 | Config value        | Explanation   |
 |-------------------- | ------------- |
 | Logging | set loglevel for `current.log` respectivly `/var/log/dbus-d0-smartmeter/current.log`. Possible values among others are `DEBUG`, `INFO`, `WARING` |
+| Protocol | set protocol to `SML` or `D0` |
 | SignOfLiveLog | if >0, interval in minutes to give stats (= number of received correct SML-data) |
 | CustomName | user-friendly name for the gridmeter within the Venus web-GUI |
 | TimeoutInterval | if no valid data is received within this millisencods-interval, the DBUS-service-property Connected will be set to 0 |
@@ -54,6 +55,7 @@ You have to edit `config.ini`. Please note the comments there as explanation!
 | Regex | Here is the magic. See Debugging-section below. |
 | ReadInterval within [USB]-Section | millisecond-interval the script reads data from TTY. This should be obviously <1000. Otherwise, the TTY-buffer would fill up resulting in outdated data |
 | Devicename within [USB]-Section | provides the correct name listed within /dev/serial/by-id/. This TTY is only used when the scipt is manually started without command-line-arguments. |
+| Bytesize | change the serial connection byte size typical `8` for some D0 meters `7` |
 
 You have to set the `DEV`-variable within `service/run` to your USB-TTY-adapter. E.g. for me, it's `DEV='/dev/serial/by-id/usb-Prolific_Technology_Inc._USB-Serial_Controller-if00-port0'`. Because `service/run` will identify the corresponding /dev/ttyUSB-device, stop the serial-starter for this TTY and start the script with this TTY as command-line-argument.
  

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ You have to edit `config.ini`. Please note the comments there as explanation!
 | Config value        | Explanation   |
 |-------------------- | ------------- |
 | Logging | set loglevel for `current.log` respectivly `/var/log/dbus-d0-smartmeter/current.log`. Possible values among others are `DEBUG`, `INFO`, `WARING` |
-| Protocol | set protocol to `SML` or `D0` |
 | SignOfLiveLog | if >0, interval in minutes to give stats (= number of received correct SML-data) |
 | CustomName | user-friendly name for the gridmeter within the Venus web-GUI |
 | TimeoutInterval | if no valid data is received within this millisencods-interval, the DBUS-service-property Connected will be set to 0 |
@@ -55,7 +54,6 @@ You have to edit `config.ini`. Please note the comments there as explanation!
 | Regex | Here is the magic. See Debugging-section below. |
 | ReadInterval within [USB]-Section | millisecond-interval the script reads data from TTY. This should be obviously <1000. Otherwise, the TTY-buffer would fill up resulting in outdated data |
 | Devicename within [USB]-Section | provides the correct name listed within /dev/serial/by-id/. This TTY is only used when the scipt is manually started without command-line-arguments. |
-| Bytesize | change the serial connection byte size typical `8` for some D0 meters `7` |
 
 You have to set the `DEV`-variable within `service/run` to your USB-TTY-adapter. E.g. for me, it's `DEV='/dev/serial/by-id/usb-Prolific_Technology_Inc._USB-Serial_Controller-if00-port0'`. Because `service/run` will identify the corresponding /dev/ttyUSB-device, stop the serial-starter for this TTY and start the script with this TTY as command-line-argument.
  

--- a/dbus-d0-smartmeter.py
+++ b/dbus-d0-smartmeter.py
@@ -124,14 +124,14 @@ class DbusttysmartmeterService:
     deviceinstance = int(config['DEFAULT']['Deviceinstance'])
     customname = config['DEFAULT']['CustomName']
     devicename = config[accesstype]['Devicename']
-    devicepath = '/dev/serial/by-id/%s' %devicename
+    deviceserialid = '/dev/serial/by-id/%s' %devicename
+    devicepath = os.popen('readlink -f /dev/serial/by-id/%s' %devicename).read().replace('\n', '')
+    ttyname = devicepath.replace('/dev/', '')
+    os.system('/opt/victronenergy/serial-starter/stop-tty.sh %s' %ttyname)
+
     self._initialized = not (len(sys.argv) >= 2)
     logging.info("current initialized-state = %r" %self._initialized)
-    if self._initialized:
-      devicename = config[accesstype]['Devicename']
-    else:
-      devicename = sys.argv[1]
-      devicepath = '/dev/%s' %devicename
+
     devicebaudrate = int(config[accesstype]['Baudrate'])
     readinterval = int(config[accesstype]['ReadInterval'])
     self._timeoutInterval = int(config['DEFAULT']['TimeoutInterval'])

--- a/service/run
+++ b/service/run
@@ -1,22 +1,2 @@
 #!/bin/sh
-
-#set -x
-
-##_
-DEV='/dev/serial/by-id/usb-Prolific_Technology_Inc._USB-Serial_Controller-if00-port0'
-
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-SERVICE_NAME=$( basename $(realpath $SCRIPT_DIR/.. ) )
-TTY=$( realpath $DEV | sed -n 's/^\/dev\///p' )
-
-echo "*** starting $SERVICE_NAME ***"
-
-echo "$DEV seams to be $TTY"
-
-echo "stopping serial-starter on $TTY"
-/opt/victronenergy/serial-starter/stop-tty.sh $TTY
-
-echo "starting python-script"
-
-exec 2>&1
-python $( realpath $SCRIPT_DIR/../${SERVICE_NAME}.py ) $TTY
+python /data/dbus-d0-smartmeter/dbus-d0-smartmeter.py


### PR DESCRIPTION
Hello,

I moved the TTY detection and serial serial-starter stop-tty to the dbus-d0-smartmeter.py 
It fixes #1 

It is no longer needed to edit `DEV` in `service/run` file. We read it directly from config.ini.